### PR TITLE
I'm just sharing this here; it was done in a rush and most likely doesn't work perfectly, but it gives the idea.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 </p>
 
 <p align="center">
-  <a href="loadstring(game:HttpGet("https://raw.githubusercontent.com/ryknuq/overvoltage/refs/heads/main/overvoltage.lua"))()">
-    loadstring(game:HttpGet("https://raw.githubusercontent.com/ryknuq/overvoltage/refs/heads/main/overvoltage.lua"))()
+  <a href="loadstring(game:HttpGet("https://raw.githubusercontent.com/HiIxX0Dexter0XxIiH/PVE-Overvolatage/refs/heads/main/overvoltage.lua"))()">
+    loadstring(game:HttpGet("https://raw.githubusercontent.com/HiIxX0Dexter0XxIiH/PVE-Overvolatage/refs/heads/main/overvoltage.lua"))()
   </a>
 </p>
 ---
 
 ## 🚀 Overview
 
-**Overvoltage v2** is a powerful, modular Lua script for Roblox that brings advanced ESP (Extra Sensory Perception) and Aimbot features to your games. Designed for performance, customization, and ease of use, Overvoltage v2 is the ultimate tool for gaining a tactical advantage.
+Now work on PVE
 
 ---
 
@@ -52,20 +52,9 @@
 ---
 
 ## 🙏 Credits
-
-- **Script Author:** [rych](https://github.com/ryknuq)
+- **Original Script** [rych](https://github.com/ryknuq/overvoltage/)
+- **Original Script Author:** [rych](https://github.com/ryknuq)
 - **UI Library:** [TokyoLib](https://github.com/drillygzzly/Roblox-UI-Libs)
 - **Contributors:**  
   - [pxul](https://github.com/0pxul/GPT-hook)
-  - He helped finding things in Dex
-
----
-
-## ⭐ Star This Project!
-
-If you like Overvoltage v2, please consider starring the repository and sharing it with others!
-
-<p align="center">
-  <img src="https://img.shields.io/github/stars/yourusername/overvoltage-v2?style=social" alt="GitHub Stars">
-</p>
-
+  - He helped findin things in Dex

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Now work on PVE
 ---
 
 ## 🙏 Credits
-- **Original Script** [rych](https://github.com/ryknuq/overvoltage/)
+- **Original Script** [rych/overvoltage](https://github.com/ryknuq/overvoltage/)
 - **Original Script Author:** [rych](https://github.com/ryknuq)
 - **UI Library:** [TokyoLib](https://github.com/drillygzzly/Roblox-UI-Libs)
 - **Contributors:**  

--- a/overvoltage.lua
+++ b/overvoltage.lua
@@ -1,5 +1,13 @@
-
---!optimize 2
+local function isValidNPC(model)
+    if model:IsA("Model") and model.Name == "Male" then
+        for _, child in ipairs(model:GetChildren()) do
+            if child:IsA("Model") and child.Name:sub(1, 3) == "AI_" then
+                return true
+            end
+        end
+    end
+    return false
+end
 
 -- === ESP CONSTANTS ===
 local ESP_CONSTANTS = {
@@ -479,7 +487,8 @@ local function scanForRemovals(cachedWorkspaceChildren)
     local workspaceChildren = cachedWorkspaceChildren or Workspace:GetChildren()
     local foundModels = {}
     for _, instance in ipairs(workspaceChildren) do
-        if instance:IsA("Model") and instance.Name == ESP_CONSTANTS.TARGET_PARENT_MODEL_NAME then
+       -- if instance:IsA("Model") and instance.Name == ESP_CONSTANTS.TARGET_PARENT_MODEL_NAME then
+       if isValidNPC(instance) then
             local model = instance
             local dataTable = activeTargets[model] or {}
             if isRemovalEnabled(ESP_CONSTANTS.REMOVAL_TYPES.HIDE_CHILD_MODELS) then
@@ -623,7 +632,8 @@ local function scanForCombinedESPTargets(cachedWorkspaceChildren, cachedDescenda
     local foundInScan = {}
     local workspaceChildren = cachedWorkspaceChildren or Workspace:GetChildren()
     for _, instance in ipairs(workspaceChildren) do
-        if instance:IsA("Model") and instance.Name == ESP_CONSTANTS.TARGET_PARENT_MODEL_NAME then
+       --if instance:IsA("Model") and instance.Name == ESP_CONSTANTS.TARGET_PARENT_MODEL_NAME then 
+       if isValidNPC(instance) then
             local model = instance; local dataTable = activeTargets[model] or { HiddenChildParts = {}, HiddenHeadDecals = {} }
             local headPart = model:FindFirstChild(ESP_CONSTANTS.TARGET_HEAD_PART_NAME)
             if headPart and headPart:IsA("BasePart") then
@@ -1178,7 +1188,7 @@ local function getClosestESPHead(wallCheck)
     local closestDist = math.huge
     local screenCenter = Vector2.new(Camera.ViewportSize.X / 2, Camera.ViewportSize.Y / 2)
     for _, model in ipairs(Workspace:GetChildren()) do
-        if model:IsA("Model") and model.Name == ESP_CONSTANTS.TARGET_PARENT_MODEL_NAME and model.Parent and isAlive(model) then
+        if isValidNPC(model) and isAlive(model) then
             local head = model:FindFirstChild(ESP_CONSTANTS.TARGET_HEAD_PART_NAME)
             if head and head:IsA("BasePart") then
                 local screenPos, onScreen = Camera:WorldToViewportPoint(head.Position)


### PR DESCRIPTION
Hi, I modified your script so it works with PVE mode. Basically, it makes the aimbot and other features only apply to NPCs and not to players. How do I know it's an NPC? Well, the script looks in the workspace for all models named "Male" and then checks each one to see if it contains a model that starts with "AI_". Most NPCs have at least one model that starts with "AI_", so if it finds one, it knows it's an NPC and should aim at it. If it doesn't find one, it means it shouldn't.

Honestly, I don't know much about scripting—I just do what I can with the help of ChatGPT, Copilot, etc. I'm not really looking for recognition or anything; I just care about having a good free script available for both PVE and PVP in BHRM5, like in the old days when most people made scripts for themselves and shared them with the community without asking for anything in return except support.

Also, if you're interested, you can check out my BHRM5 script where I implemented a "Silent Aim" for PVE mode, but it's kind of silly—it just enlarges the NPCs' torso so they have a bigger hitbox.